### PR TITLE
-aオプションを実装

### DIFF
--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -1,13 +1,22 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
+require 'optparse'
+
 COLUMN_COUNT = 3
 
 def main
-  files = Dir.glob('*').sort_by(&:downcase)
+  params = ARGV.getopts('a')
+  files = prepared_files(params)
   row_count = files.count.ceildiv(COLUMN_COUNT)
   columns = split_into_columns(files, COLUMN_COUNT, row_count)
   output(columns, row_count)
+end
+
+# -rオプションもprepared_filesメソッドに実装予定
+def prepared_files(params)
+  raw_files = Dir.glob('*', params['a'] ? File::FNM_DOTMATCH : 0)
+  raw_files.sort_by { |x| x.gsub(/[^a-z0-9]/i, '').downcase }
 end
 
 def split_into_columns(files, column_count, row_count)
@@ -22,11 +31,11 @@ end
 def output(columns, row_count)
   column_widths = columns.map { |words| words.map(&:size).max }
   row_count.times do |row_idx|
-    columns.each_with_index do |col, col_idx|
+    cols = columns.filter_map.with_index do |col, col_idx|
       filename = col[row_idx]
-      print "#{filename.ljust(column_widths[col_idx])}  " if filename
+      filename&.ljust(column_widths[col_idx])
     end
-    print "\n"
+    puts cols.join('  ')
   end
 end
 

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -6,17 +6,18 @@ require 'optparse'
 COLUMN_COUNT = 3
 
 def main
-  params = ARGV.getopts('a')
-  files = prepared_files(params)
+  options = ARGV.getopts('a')
+  files = prepare_files(options)
   row_count = files.count.ceildiv(COLUMN_COUNT)
   columns = split_into_columns(files, COLUMN_COUNT, row_count)
   output(columns, row_count)
 end
 
 # -rオプションもprepared_filesメソッドに実装予定
-def prepared_files(params)
-  raw_files = Dir.glob('*', params['a'] ? File::FNM_DOTMATCH : 0)
-  raw_files.sort_by { |x| x.gsub(/[^a-z0-9]/i, '').downcase }
+def prepare_files(options)
+  dotmatch_option = options['a'] ? File::FNM_DOTMATCH : 0
+  raw_files = Dir.glob('*', dotmatch_option)
+  raw_files.sort_by { |f| f.gsub(/[^a-z0-9]/i, '').downcase }
 end
 
 def split_into_columns(files, column_count, row_count)


### PR DESCRIPTION
## 変更内容
`-a`オプションを実装しました

## 詳細

### prepared_filesメソッドを新たに追加
 prepared_filesメソッドを新たに追加し、`-a`選択時に隠しファイルも含めて表示できるようにしました。
```ruby
raw_files = Dir.glob('*', params['a'] ? File::FNM_DOTMATCH : 0)
```
### sort_byの方法を変更
`.`や`-`などの記号があると半角英数字よりも前に表示されてしまうため、下記の通り半角英数字以外はいったん取り除いてソートするようにしました。
  >lsコマンドの課題としては「全部半角英数字だけのファイル名で構成する」とか「アスキー文字以外は全部全角文字と見なす(‗も全角文字扱いで構わない)」といったシンプルな対応でも全然問題ありません
  
  [こちら](https://bootcamp.fjord.jp/questions/1958)のQ&Aにて、伊藤さんが上記の通りコメントされていたので、ひとまず半角英数字だけを考慮して実装しております🙇‍♀️
```ruby
raw_files.sort_by { |x| x.gsub(/[^a-z0-9]/i, '').downcase }
```
###  outputメソッド内の計算式を修正
[前回PRのコメント](https://github.com/Kimmy-2ka/ruby-practices/pull/4#discussion_r2131208575)で参考情報いただきありがとうございました！`filter_map`でnilを除外して、その後`.join`でまとめる方法、とても参考になりました。確かに、私の以前のコードだと最後の列の後ろにもスペースが無駄なスペースが発生してしまいますね…。
自分で理解するためにも今のコードに実装してみたかったので、伊藤さんに提案いただいた内容に修正いたしました。

また、下記部分に対し、rubocopで下記のように指摘を受けたため、`&.`を追加し`if filename`は削除しております。

**ご提案いただいた内容：**
![image](https://github.com/user-attachments/assets/dc1dfb59-9515-40a5-ba9f-5ae5b2cb5059)

**変更内容：**
```ruby
filename&.ljust(column_widths[col_idx])
```
（`filter_map`で`nil`を除外しているのに`&.`をつけるというのは念のための処理ということなんでしょうか💦)

**rubocopの指摘：**
```ruby
ls.rb:36:7: C: [Correctable] Style/SafeNavigation: Use safe navigation (&.) instead of checking if an object exists before calling the method.
      filename.ljust(column_widths[col_idx]) if filename
```