### PR TITLE
-rオプションを実装

### DIFF
--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -6,18 +6,18 @@ require 'optparse'
 COLUMN_COUNT = 3
 
 def main
-  options = ARGV.getopts('a')
+  options = ARGV.getopts('ar')
   files = prepare_files(options)
   row_count = files.count.ceildiv(COLUMN_COUNT)
   columns = split_into_columns(files, COLUMN_COUNT, row_count)
   output(columns, row_count)
 end
 
-# -rオプションもprepared_filesメソッドに実装予定
 def prepare_files(options)
-  dotmatch_option = options['a'] ? File::FNM_DOTMATCH : 0
-  raw_files = Dir.glob('*', dotmatch_option)
-  raw_files.sort_by { |f| f.gsub(/[^a-z0-9]/i, '').downcase }
+  flags = options['a'] ? File::FNM_DOTMATCH : 0
+  files = Dir.glob('*', flags)
+  sorted_files = files.sort_by { |f| f.gsub(/[^a-z0-9]/i, '').downcase }
+  options['r'] ? sorted_files.reverse : sorted_files
 end
 
 def split_into_columns(files, column_count, row_count)


### PR DESCRIPTION
## 変更内容
`-r`オプションを実装、変数名の変更を行いました。

## 詳細
### -rオプションを実装
`prepare_file`メソッド内に下記コードを実装し、`-r`オプションが指定された場合にファイル順を逆に表示するようにしました。
```ruby
options['r'] ? sorted_files.reverse : sorted_files
```
### 変数名の変更
前回のPRのレビューコメントを基に、変数名を変更しました。
- 17行目：dotmatch_option→flags
`Dir.glob`の第２引数の名称がflagsであったため、変数名もflagsに変更しました。
- 18行目：raw_files→files
raw-filesはシンプルにfilesとし、ソートされたファイルは区別が出来るようにsorted_filesとしました。