### PR TITLE
lsコマンドを作る5課題提出：mainの内容を簡潔化した

### DIFF
--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -36,14 +36,7 @@ COLUMN_COUNT = 3
 def main
   options = ARGV.getopts('alr')
   files = prepare_files(options)
-  if options['l']
-    file_details = prepare_file_details(files)
-    output_long_format(file_details)
-  else
-    row_count = files.count.ceildiv(COLUMN_COUNT)
-    columns = split_into_columns(files, COLUMN_COUNT, row_count)
-    output_short_format(columns, row_count)
-  end
+  options['l'] ? output_long_format(files) : output_short_format(files)
 end
 
 def prepare_files(options)
@@ -103,7 +96,8 @@ def apply_special_permission(special_flag, permission)
   "#{permission[:r]}#{permission[:w]}#{execute_char}"
 end
 
-def output_long_format(file_details)
+def output_long_format(files)
+  file_details = prepare_file_details(files)
   puts "total #{file_details.sum { |f| f[:blocks] } / 2}"
   widths =
     %i[link owner_name group_name size].to_h do |key|
@@ -135,7 +129,9 @@ def split_into_columns(files, column_count, row_count)
   column_group
 end
 
-def output_short_format(columns, row_count)
+def output_short_format(files)
+  row_count = files.count.ceildiv(COLUMN_COUNT)
+  columns = split_into_columns(files, COLUMN_COUNT, row_count)
   column_widths = columns.map { |words| words.map(&:size).max }
   row_count.times do |row_idx|
     cols = columns.filter_map.with_index do |col, col_idx|


### PR DESCRIPTION
## 変更内容
lsコマンドを作る5の課題を作成しました。
`main`の内容を簡潔化しました。
### 詳細
- `main`メソッド内において、`options['l']` の分岐が long/shortで対称になるように修正しました。
```ruby
options['l'] ? output_long_format(files) : output_short_format(files)
```
- `file_details = prepare_file_details(files)` →output_long_format内に移動
-  `row_count = files.count.ceildiv(COLUMN_COUNT)` →output_short_format内に移動
-  `columns = split_into_columns(files, COLUMN_COUNT, row_count)` →output_short_format内に移動